### PR TITLE
Update fcpy.sh

### DIFF
--- a/files/fcpy.sh
+++ b/files/fcpy.sh
@@ -17,7 +17,6 @@ if [ -d "/opt/srv" ]; then
     sed -i 's/127.0.0.1/0.0.0.0/g' /opt/server/SPT_Data/Server/configs/http.json
     NODE_CHANNEL_FD= timeout --preserve-status 40s ./SPT.Server.exe </dev/null >/dev/null 2>&1 
     echo "Follow the instructions to proceed!"
-    exit 0
 fi
 
 if [ -e "/opt/server/delete_me" ]; then


### PR DESCRIPTION
Remove the "exit 0" so the script continues and the container works right off the bat. Instead of kill the container and restarting a stopped container.  With this change this will also work in a docker stack as a service. Since a service will never restart a stopped container but spin up a new one.