### PR TITLE
Must have V present in branch version selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ CMD bash ./fcpy.sh
 
 Press **Ctrl + S** to save and after that press **Ctrl + X** to exit.
 
-You can change the Fika and SPT versions If SPT or FIKA gets updated. In the `Dockerfile` you can change `FIKA_BRANCH` and `SPT_BRANCH` args to the version you want. E.g. `ARG SPT_BRANCH=3.8.1`.
+You can change the Fika and SPT versions If SPT or FIKA gets updated. In the `Dockerfile` you can change `FIKA_BRANCH` and `SPT_BRANCH` args to the version you want. E.g. `ARG SPT_BRANCH=v3.8.1`.
 
 
 And then we will create a new file called "fcpy.sh" in the fika directory. **THIS NAME IS CASE SENSITIVE**


### PR DESCRIPTION
In the event you want to specify the version in the build, you must use v in front of the version in BRANCH=. 