### PR TITLE
Use tags Instead of branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ CMD bash ./fcpy.sh
 
 Press **Ctrl + S** to save and after that press **Ctrl + X** to exit.
 
-You can change the Fika and SPT versions If SPT or FIKA gets updated. In the `Dockerfile` you can change `FIKA_BRANCH` and `SPT_BRANCH` args to the version you want. E.g. `ARG SPT_BRANCH=v3.8.1`.
+You can change the Fika and SPT versions If SPT or FIKA gets updated. In the `Dockerfile` you can change `FIKA_TAG` and `SPT_TAG` args to the version you want. E.g. `ARG FIKA_TAG=v2.1.1` and `ARG SPT_TAG=3.8.3`.
 
 ![#f03c15](https://placehold.co/15x15/f03c15/ff0000.png) **Warning!** ![#f03c15](https://placehold.co/15x15/f03c15/ff0000.png) Make sure that selected tag versions are compatible. **Please double check the current versions of SPT and Fika!**
 

--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -5,9 +5,9 @@
 
 FROM ubuntu:latest AS builder
 ARG FIKA=HEAD^
-ARG FIKA_BRANCH=main
+ARG FIKA_TAG=[Insert Tag Here]
 ARG SPT=HEAD^
-ARG SPT_BRANCH=master
+ARG SPT_TAG=[Insert Tag Here]
 ARG NODE=20.11.1
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
@@ -19,10 +19,12 @@ RUN apt update && apt install -yq git git-lfs curl
 RUN git clone https://github.com/nvm-sh/nvm.git $HOME/.nvm || true
 RUN \. $HOME/.nvm/nvm.sh && nvm install $NODE
 ## Clone the SPT repo or continue if it exist
-RUN git clone --branch $SPT_BRANCH https://dev.sp-tarkov.com/SPT/Server.git srv || true
+RUN git clone https://dev.sp-tarkov.com/SPT/Server.git srv || true
 
 ## Check out and git-lfs (specific commit --build-arg SPT=xxxx)
 WORKDIR /opt/srv/project
+
+RUN git checkout tags/$SPT_TAG
 RUN git checkout $SPT
 RUN git-lfs pull
 
@@ -36,9 +38,12 @@ RUN mv build/ /opt/server/
 WORKDIR /opt
 RUN rm -rf srv/
 ## Grab FIKA Server Mod or continue if it exist
-RUN git clone --branch $FIKA_BRANCH https://github.com/project-fika/Fika-Server.git ./server/user/mods/fika-server
-RUN \. $HOME/.nvm/nvm.sh && cd ./server/user/mods/fika-server && git checkout $FIKA && npm install
-RUN rm -rf ./server/user/mods/FIKA/.git
+RUN git clone https://github.com/project-fika/Fika-Server.git ./server/user/mods/fika-server
+WORKDIR ./server/user/mods/fika-server
+RUN git checkout tags/$FIKA_TAG
+RUN git checkout $FIKA
+RUN \. $HOME/.nvm/nvm.sh && npm install
+RUN rm -rf ../FIKA/.git
 
 FROM ubuntu:latest
 WORKDIR /opt/

--- a/files/fcpy.sh
+++ b/files/fcpy.sh
@@ -14,8 +14,13 @@ if [ -d "/opt/srv" ]; then
     echo "Starting the server to generate all the required files"
     cd /opt/server
     chown $(id -u):$(id -g) ./* -Rf
-    sed -i 's/127.0.0.1/0.0.0.0/g' /opt/server/SPT_Data/Server/configs/http.json
-    NODE_CHANNEL_FD= timeout --preserve-status 40s ./SPT.Server.exe </dev/null >/dev/null 2>&1 
+    if [ -f /opt/server/SPT_Data/Server/configs/http.json ]; then
+    	sed -i 's/127.0.0.1/0.0.0.0/g' /opt/server/SPT_Data/Server/configs/http.json
+	NODE_CHANNEL_FD= timeout --preserve-status 40s ./SPT.Server.exe </dev/null >/dev/null 2>&1
+    else
+	sed -i 's/127.0.0.1/0.0.0.0/g' /opt/server/Aki_Data/Server/configs/http.json
+	NODE_CHANNEL_FD= timeout --preserve-status 40s ./Aki.Server.exe </dev/null >/dev/null 2>&1
+    fi
     echo "Follow the instructions to proceed!"
 fi
 
@@ -26,7 +31,12 @@ if [ -e "/opt/server/delete_me" ]; then
     exit 1
 fi
 
-cd /opt/server && ./SPT.Server.exe
+cd /opt/server
 
+if [ -f ./SPT.Server.exe ]; then
+   ./SPT.Server.exe
+else
+   ./Aki.Server.exe
+fi
 echo "Exiting."
 exit 0


### PR DESCRIPTION
This is a change that allows the use of tags to specify specific releases of SPT and FIKA respectively. The reasons this is better is that the SPT and FIKA team seems to remove old branches after release making it hard to roll back to previous versions.

Example of the tags I used are:
FIKA_TAG=v2.1.1
SPT_TAG=3.8.3

I believe this closes #9 as well.

I'll also say thank you as well , this is a great setup process you have shared.

